### PR TITLE
fix: audit fixes for 1.1.11

### DIFF
--- a/src/app/components/AliasManagePage/hook/useAlias.ts
+++ b/src/app/components/AliasManagePage/hook/useAlias.ts
@@ -132,7 +132,7 @@ export const useAlias = ({
 				}
 			}
 
-			console.log(mode, data);
+			//
 		} catch (e) {
 			console.log(e);
 			setTransactionSuccess(false);
@@ -145,7 +145,7 @@ export const useAlias = ({
 		if (mode === 'edit') return null;
 		if (aliasInput.isEmpty) return 'This field is required';
 		if (aliasInput.minLengthError) return 'Alias must be minimum 6 symbols';
-		if (isAliasRegistred) return 'Alias name already exits';
+		if (isAliasRegistred) return 'Alias name already exists';
 		return null;
 	}, [aliasInput, isAliasRegistred, mode]);
 

--- a/src/app/components/AliasTransfer/index.tsx
+++ b/src/app/components/AliasTransfer/index.tsx
@@ -39,7 +39,7 @@ const AliasTransfer = () => {
 					/>
 
 					<p className={styles.main__transactionInfo_text}>
-						{transactionSuccess ? `Alias transfered!` : 'Transaction failed!'}
+						{transactionSuccess ? `Alias transferred!` : 'Transaction failed!'}
 					</p>
 
 					{!transactionSuccess && (

--- a/src/app/components/Wallet/Wallet.tsx
+++ b/src/app/components/Wallet/Wallet.tsx
@@ -1,6 +1,5 @@
 import React, { Dispatch, SetStateAction, useContext, useRef, useState } from 'react';
 import Decimal from 'decimal.js';
-import { styleText } from 'util';
 import copyIcon from '../../assets/svg/copy.svg';
 import dotsIcon from '../../assets/svg/dots.svg';
 import sendIcon from '../../assets/svg/send.svg';

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -318,9 +318,13 @@ async function processRequest(request: RequestType, sender: Sender, sendResponse
 			};
 			updateUserData({
 				apiCredentials,
-			}).then(() => {
-				sendResponse({ success: true });
-			});
+			})
+				.then(() => {
+					sendResponse({ success: true });
+				})
+				.catch(() => {
+					sendResponse({ error: 'Failed to save credentials' });
+				});
 			break;
 
 		case 'PING_WALLET':
@@ -574,7 +578,7 @@ async function processRequest(request: RequestType, sender: Sender, sendResponse
 			createAlias({
 				address: String(request.address),
 				alias: String(request.alias),
-				comment: request.comment,
+				comment: request.comment ? String(request.comment) : undefined,
 			})
 				.then((res) => sendResponse(res))
 				.catch(() => sendResponse({ error: 'Internal error' }));
@@ -585,7 +589,7 @@ async function processRequest(request: RequestType, sender: Sender, sendResponse
 			updateAlias({
 				address: String(request.address),
 				alias: String(request.alias),
-				comment: request.comment,
+				comment: request.comment ? String(request.comment) : undefined,
 			})
 				.then((res) => sendResponse(res))
 				.catch(() => sendResponse({ error: 'Internal error' }));


### PR DESCRIPTION
## Summary
- Fix "exits" → "exists" typo in alias registration error
- Fix "transfered" → "transferred" typo in alias transfer success
- Remove dead `import { styleText } from 'util'` (Node.js module in browser context)
- Add `.catch()` to `SET_API_CREDENTIALS` to prevent caller hanging on storage failure
- Coerce `comment` param to `String()` in REGISTER_ALIAS and UPDATE_ALIAS handlers
- Remove `console.log` of RPC response data in useAlias