### PR TITLE
ci: tighten guard sender-trust patterns + gate invariants

### DIFF
--- a/security-guard.config.json
+++ b/security-guard.config.json
@@ -7,31 +7,41 @@
       "advice": "Use isExtensionFrontend(): a web page can put the extension id in its own URL, so substring matching is forgeable."
     },
     {
-      "label": "Do not substring-match trust fields on the message sender",
-      "pattern": "sender\\.(url|origin)\\.includes\\(",
-      "advice": "Compare parsed origins (isExtensionFrontend), not substrings of sender.url/origin."
+      "label": "Do not derive trust from a substring/prefix test on sender.url/origin",
+      "pattern": "sender\\.(url|origin)\\??\\.(includes|indexOf|startsWith|endsWith|match|search)\\(",
+      "advice": "Compare parsed origins (isExtensionFrontend) — any substring/prefix API on sender.url/origin is forgeable."
     },
     {
-      "label": "Localhost gate must be an exact loopback host check, not a prefix",
-      "pattern": "\\.startsWith\\([^)]*http://localhost",
-      "advice": "Use isSecureOrigin(): startsWith('http://localhost') also admits http://localhost.evil.com."
+      "label": "Localhost gate must be an exact loopback host check, not a string test",
+      "pattern": "(includes|indexOf|match|search|startsWith)\\([^)]*http://localhost",
+      "advice": "Use isSecureOrigin() (hostname === 'localhost'/'127.0.0.1'/'[::1]'); any string test admits http://localhost.evil.com."
     }
   ],
   "require": [
     {
-      "label": "Frontend trust gate present in permission middleware",
+      "label": "Permission middleware calls the frontend trust gate",
       "file": "src/app/utils/permission.ts",
-      "pattern": "isExtensionFrontend"
+      "pattern": "isExtensionFrontend\\(sender\\)"
     },
     {
-      "label": "Frontend trust gate present in background worker",
+      "label": "Background worker calls the frontend trust gate",
       "file": "src/background/background.ts",
-      "pattern": "isExtensionFrontend"
+      "pattern": "isExtensionFrontend\\(sender\\)"
     },
     {
-      "label": "SELF_ONLY_REQUESTS gate present in background worker",
+      "label": "Background worker enforces SELF_ONLY_REQUESTS for non-frontend callers",
       "file": "src/background/background.ts",
-      "pattern": "SELF_ONLY_REQUESTS"
+      "pattern": "SELF_ONLY_REQUESTS\\.includes\\(request\\.method\\)"
+    },
+    {
+      "label": "Frontend gate compares the exact extension origin",
+      "file": "src/app/utils/utils.ts",
+      "pattern": "new URL\\(sender\\.url\\)\\.origin === EXTENSION_ORIGIN"
+    },
+    {
+      "label": "Frontend gate also checks sender.id against the extension id",
+      "file": "src/app/utils/utils.ts",
+      "pattern": "sender\\.id !== chrome\\.runtime\\.id"
     }
   ]
 }


### PR DESCRIPTION
Hardens the pattern-guard config after a cross-model review of the selected rules.

- **Broaden the forbid rules** beyond the exact 1.2.0 spellings: any substring/prefix API on `sender.url`/`sender.origin` (`includes|indexOf|startsWith|endsWith|match|search`), and any string test against `http://localhost` — not just `.includes(`/`.startsWith(`. A small refactor could otherwise reintroduce the forged-UI/localhost bug without tripping the old regex.
- **Tighten the require rules** from symbol-presence to behavior: require the call site `isExtensionFrontend(sender)` (not just the symbol), the `SELF_ONLY_REQUESTS.includes(request.method)` enforcement, and the helper invariants (`new URL(sender.url).origin === EXTENSION_ORIGIN`, `sender.id !== chrome.runtime.id`) — so the gate can't be kept-but-neutered.

Verified: passes on current main (no false positives); the broadened rules still catch the historical bad lines.