### PR TITLE
ci: bump ci-security to v1.3.0

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,4 +12,4 @@ permissions:
   actions: read
 jobs:
   codeql:
-    uses: PRavaga/ci-security/.github/workflows/codeql.yml@v1.2.0
+    uses: PRavaga/ci-security/.github/workflows/codeql.yml@v1.3.0

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -12,6 +12,6 @@ permissions:
 
 jobs:
   security:
-    uses: PRavaga/ci-security/.github/workflows/security.yml@v1.0.1
+    uses: PRavaga/ci-security/.github/workflows/security.yml@v1.3.0
     secrets:
       CLAUDE_API_KEY: ${{ secrets.CLAUDE_API_KEY }}


### PR DESCRIPTION
Repins the shared security workflows to `PRavaga/ci-security@v1.3.0`, which bumps the underlying pinned actions (checkout/setup-node/upload-artifact v5, CodeQL v3→v4) and clears the CodeQL Node-20 deprecation warnings. No behavior change to the guard or scanning — only the action versions move.